### PR TITLE
Updating for 1.7.7.1

### DIFF
--- a/ngx_openresty.spec
+++ b/ngx_openresty.spec
@@ -1,5 +1,5 @@
 Name:		ngx_openresty
-Version:	1.7.2.1
+Version:	1.7.7.1
 Release:	1%{?dist}
 Summary:	a fast web app server by extending nginx
 

--- a/ngx_openresty.spec
+++ b/ngx_openresty.spec
@@ -60,6 +60,7 @@ rm -rf %{buildroot}
 %{homedir}/nginx/logs
 %{homedir}/nginx/sbin
 %{homedir}/nginx/sbin/nginx
+%{homedir}/bin/resty
 
 %{homedir}/nginx/conf
 %{homedir}/nginx/conf/fastcgi.conf.default


### PR DESCRIPTION
Between 1.7.2.1 and 1.7.7.1 it looks like openresty added a new binary that would throw an error during rpmbuild.  I've added that file to the specfile and updated the version.
